### PR TITLE
ユーザー登録・ログイン（エラーハンドリング修正）

### DIFF
--- a/app/models/deliveryaddress.rb
+++ b/app/models/deliveryaddress.rb
@@ -76,20 +76,31 @@ class Deliveryaddress < ApplicationRecord
   end
 
   def full_width_city
-    return if city =~ /^[^ -~｡-ﾟ]*$/
-    @error_name7 = I18n.t(User.human_attribute_name(:city))
-    errors.add @error_name7, "は全角で入力してください"
+    if city.blank? 
+      @error_name7 = I18n.t(User.human_attribute_name(:city))
+      errors.add @error_name7, "は全角で入力してください"
+    elsif !(city =~ /^[^ -~｡-ﾟ]*$/)
+      @error_name7 = I18n.t(User.human_attribute_name(:city))
+      errors.add @error_name7, "は全角で入力してください"
+    else
+      return
+    end
   end
+
   def full_width_address
-    return if address =~ /^[^ -~｡-ﾟ]*$/
-    @error_name8 = I18n.t(User.human_attribute_name(:address))
-    errors.add @error_name8, "は全角で入力してください"
+    if address.blank?
+      @error_name8 = I18n.t(User.human_attribute_name(:address))
+      errors.add @error_name8, "は全角で入力してください"
+    elsif !(address =~ /^[^ -~｡-ﾟ]*$/)
+      @error_name8 = I18n.t(User.human_attribute_name(:address))
+      errors.add @error_name8, "は全角で入力してください"
+    else
+    end
   end
   def full_width_building
     return if building.blank? || building =~ /^[^ -~｡-ﾟ]*$/
     @error_name9 = I18n.t(User.human_attribute_name(:building))
     errors.add @error_name9, "は全角で入力してください"
   end
-
-
+a
 end

--- a/app/models/deliveryaddress.rb
+++ b/app/models/deliveryaddress.rb
@@ -102,5 +102,4 @@ class Deliveryaddress < ApplicationRecord
     @error_name9 = I18n.t(User.human_attribute_name(:building))
     errors.add @error_name9, "は全角で入力してください"
   end
-a
 end

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -6,8 +6,7 @@
       会員情報入力
     .login-main__content
       .login-main__content__form
-        = form_with(model: @user, url: profileaddresses_path,local: true,method: :post) do |f|
-          = render "devise/shared/error_messages", resource: @user  
+        = form_with(model: @user, url: profileaddresses_path,local: true,method: :post) do |f|  
 
           .form-group
             ニックネーム
@@ -16,7 +15,17 @@
             %br
             .field
               = f.text_field :nickname, autofocus: true, autocomplete: "nickname",placeholder: "例）フリマ太郎",class: "default"            
-         
+              - if @user.errors.any?
+                .error_explanation
+                  %h2
+                    - I18n.t("errors.messages.not_saved",                 |
+                      count: resource.errors.count,                       |
+                      resource: resource.class.model_name.human.downcase) |
+                  %ul
+                    - @user.errors.full_messages_for(:nickname).each do |message|
+                      %li{style: "color:red"}
+                        = message
+
           .form-group
             メールアドレス
             %span.required
@@ -24,7 +33,17 @@
             %br
             .field
               = f.text_field :email, autofocus: true, autocomplete: "email", placeholder: "PC・携帯どちらでも可", class:"default"         
-         
+              - if @user.errors.any?
+                .error_explanation
+                  %h2
+                    - I18n.t("errors.messages.not_saved",                 |
+                      count: resource.errors.count,                       |
+                      resource: resource.class.model_name.human.downcase) |
+                  %ul
+                    - @user.errors.full_messages_for(:email).each do |message|
+                      %li{style: "color:red"}
+                        = message
+
           .form-group
             パスワード
             %span.required
@@ -33,8 +52,17 @@
             .field
               = f.password_field :password, autocomplete: "new-password", placeholder: "７文字以上",class: "default"
             %p.info ※英字と数字の両方を含めて設定してください
-            -# 後にチェックボックスはJSで動作を組んでください
-          
+            - if @user.errors.any?
+              .error_explanation
+                %h2
+                  - I18n.t("errors.messages.not_saved",                 |
+                    count: resource.errors.count,                       |
+                    resource: resource.class.model_name.human.downcase) |
+                %ul
+                  - @user.errors.full_messages_for(:password).each do |message|
+                    %li{style: "color:red"}
+                      = message
+
           .form-group 
             パスワード（確認用）
             %span.required
@@ -42,7 +70,17 @@
             %br
             .field
               = f.password_field :password_confirmation, autocomplete: "new-password",placeholder: "もう一度パスワードを入力してください",class:"default"
-          
+              - if @user.errors.any?
+                .error_explanation
+                  %h2
+                    - I18n.t("errors.messages.not_saved",                 |
+                      count: resource.errors.count,                       |
+                      resource: resource.class.model_name.human.downcase) |
+                  %ul
+                    - @user.errors.full_messages_for(:password_confirmation).each do |message|
+                      %li{style: "color:red"}
+                        = message
+
           .form-group
             本人確認
             %p.info-text 安心・安全にご利用いただく為に、お客様の本人情報の登録にご協力ください。他のお客様に公開されることはありません。
@@ -54,7 +92,28 @@
             %br
             .field
               = f.text_field :family_name, autofocus: true, autocomplete: "family_name",placeholder: "例）山田",class: "default half"           
-              = f.text_field :given_name, autofocus: true, autocomplete: "given_name",placeholder: "例）太郎",class: "default half__right"        
+              = f.text_field :given_name, autofocus: true, autocomplete: "given_name",placeholder: "例）太郎",class: "default half__right"
+              - if @user.errors.any?
+                .error_explanation
+                  %h2
+                    - I18n.t("errors.messages.not_saved",                 |
+                      count: resource.errors.count,                       |
+                      resource: resource.class.model_name.human.downcase) |
+                  %ul
+                    - @user.errors.full_messages_for(:family_name).each do |message|
+                      %li{style: "color:red"}
+                        = message
+              - if @user.errors.any?
+                .error_explanation
+                  %h2
+                    - I18n.t("errors.messages.not_saved",                 |
+                      count: resource.errors.count,                       |
+                      resource: resource.class.model_name.human.downcase) |
+                  %ul
+                    - @user.errors.full_messages_for(:given_name).each do |message|
+                      %li{style: "color:red"}
+                        = message
+
           .form-group
             お名前カナ(全角)
             %span.required
@@ -63,6 +122,26 @@
             .field
               = f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana",placeholder: "例）ヤマダ",class: "default half"           
               = f.text_field :given_name_kana, autofocus: true, autocomplete: "given_name_kana",placeholder: "例）タロウ",class: "default half__right"
+              - if @user.errors.any?
+                .error_explanation
+                  %h2
+                    - I18n.t("errors.messages.not_saved",                 |
+                      count: resource.errors.count,                       |
+                      resource: resource.class.model_name.human.downcase) |
+                  %ul
+                    - @user.errors.full_messages_for(:family_name_kana).each do |message|
+                      %li{style: "color:red"}
+                        = message
+              - if @user.errors.any?
+                .error_explanation
+                  %h2
+                    - I18n.t("errors.messages.not_saved",                 |
+                      count: resource.errors.count,                       |
+                      resource: resource.class.model_name.human.downcase) |
+                  %ul
+                    - @user.errors.full_messages_for(:given_name_kana).each do |message|
+                      %li{style: "color:red"}
+                        = message
 
           .form-group
             生年月日
@@ -71,9 +150,18 @@
             %br
             .field
               != sprintf(f.date_select(:birthday, prefix:'birthday',with_css_classes:'XXXXX', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s'),'年','月')+'日'
-            -# 上は↓の内容と同じ
-            -# = f.date_field :birthday, autofocus: true, autocomplete: "birthday",class:"default"
-                      
+                  
+              - if @user.errors.any?
+                .error_explanation
+                  %h2
+                    - I18n.t("errors.messages.not_saved",                 |
+                      count: resource.errors.count,                       |
+                      resource: resource.class.model_name.human.downcase) |
+                  %ul
+                    - @user.errors.full_messages_for(:birthday).each do |message|
+                      %li{style: "color:red"}
+                        = message
+        
 
           .form-group
             .actions
@@ -85,25 +173,3 @@
             
   .login-footer
     = render partial: '/template/input-bottom'
-
--# %h2 Sign up
--# = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
--#   = render "devise/shared/error_messages", resource: resource
--#   .field
--#     = f.label :email
--#     %br/
--#     = f.email_field :email, autofocus: true, autocomplete: "email"
--#   .field
--#     = f.label :password
--#     - if @minimum_password_length
--#       %em
--#         (#{@minimum_password_length} characters minimum)
--#     %br/
--#     = f.password_field :password, autocomplete: "new-password"
--#   .field
--#     = f.label :password_confirmation
--#     %br/
--#     = f.password_field :password_confirmation, autocomplete: "new-password"
--#   .actions
--#     = f.submit "Sign up"
--# = render "users/shared/links"

--- a/app/views/users/registrations/new_deliveryaddresses.html.haml
+++ b/app/views/users/registrations/new_deliveryaddresses.html.haml
@@ -8,12 +8,6 @@
       .login-main__content__form
         = form_with(model: @deliveryaddress,url: user_registration_path,local: true) do |f|
           -# = render "devise/shared/error_messages", resource: resource
-          -if @deliveryaddress.errors.any?
-            .alert.alert-warning
-              %ul
-                - @deliveryaddress.errors.full_messages.each do |message|
-                  %li 
-                    = message.delete!("Translation missing: ja")
 
           .form-group
             お名前(全角)
@@ -23,7 +17,20 @@
             .field
               = f.text_field :family_name, autofocus: true, autocomplete: "family_name",placeholder: "例）山田",class: "default half"           
               = f.text_field :given_name, autofocus: true, autocomplete: "given_name",placeholder: "例）太郎",class: "default half__right"       
-
+              -if @deliveryaddress.errors.any?
+                .alert.alert-warning
+                  %ul
+                    - @deliveryaddress.errors.full_messages.each do |message|
+                      %li{style: "color:red"} 
+                        - if message.include?("名字は")
+                          = message.delete!("Translation missing: ja")
+              -if @deliveryaddress.errors.any?
+                .alert.alert-warning
+                  %ul
+                    - @deliveryaddress.errors.full_messages.each do |message|
+                      %li{style: "color:red"} 
+                        - if message.include?("名前は")
+                          = message.delete!("Translation missing: ja")
           .form-group
             お名前カナ(全角)
             %span.required
@@ -32,7 +39,20 @@
             .field
               = f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana",placeholder: "例）ヤマダ",class: "default half"           
               = f.text_field :given_name_kana, autofocus: true, autocomplete: "given_name_kana",placeholder: "例）タロウ",class: "default half__right"
-
+              -if @deliveryaddress.errors.any?
+                .alert.alert-warning
+                  %ul
+                    - @deliveryaddress.errors.full_messages.each do |message|
+                      %li{style: "color:red"} 
+                        - if message.include?("名字（カナ）は")
+                          = message.delete!("Translation missing: ja")
+              -if @deliveryaddress.errors.any?
+                .alert.alert-warning
+                  %ul
+                    - @deliveryaddress.errors.full_messages.each do |message|
+                      %li{style: "color:red"} 
+                        - if message.include?("名前（カナ）は")
+                          = message.delete!("Translation missing: ja")
           .form-group
             郵便番号 
             %span.required
@@ -40,7 +60,13 @@
             %br 
             .field
               = f.text_field :postal_code, autofocus: true, autocomplete: "postal_code",placeholder: "ーーー",class: "default"
-
+              -if @deliveryaddress.errors.any?
+                .alert.alert-warning
+                  %ul
+                    - @deliveryaddress.errors.full_messages.each do |message|
+                      %li{style: "color:red"} 
+                        - if message.include?("郵便番号")
+                          = message.delete!("Translation missing: ja")
             .form-group
               -#  後に、都道府県を選べるようコードを書き換えてください
               都道府県 
@@ -58,7 +84,13 @@
               %br            
               .field
                 = f.text_field :city, autofocus: true, autocomplete: "city",placeholder: "ーーー",class: "default" 
-
+                -if @deliveryaddress.errors.any?
+                  .alert.alert-warning
+                    %ul
+                      - @deliveryaddress.errors.full_messages.each do |message|
+                        %li{style: "color:red"} 
+                          - if message.include?("市区町村")
+                            = message.delete!("Translation missing: ja")
             .form-group
               番地
               %span.required
@@ -66,7 +98,13 @@
               %br             
               .field
                 = f.text_field :address, autofocus: true, autocomplete: "address",placeholder: "ーーー",class: "default" 
-
+                -if @deliveryaddress.errors.any?
+                  .alert.alert-warning
+                    %ul
+                      - @deliveryaddress.errors.full_messages.each do |message|
+                        %li{style: "color:red"} 
+                          - if message.include?("番地")
+                            = message.delete!("Translation missing: ja")
             .form-group
               マンション名など部屋号室
               %span.any
@@ -74,7 +112,13 @@
               %br
               .field 
                 = f.text_field :building, autofocus: true, autocomplete: "building",placeholder: "ーーー",class: "default"  
-
+                -if @deliveryaddress.errors.any?
+                  .alert.alert-warning
+                    %ul
+                      - @deliveryaddress.errors.full_messages.each do |message|
+                        %li{style: "color:red"} 
+                          - if message.include?("マンション")
+                            = message.delete!("Translation missing: ja")
             .form-group
               電話番号
               %span.any
@@ -82,7 +126,13 @@
               %br
               .field 
                 = f.text_field :phone_number, autofocus: true, autocomplete: "phone_number",placeholder: "ーーー",class: "default" 
-
+                -if @deliveryaddress.errors.any?
+                  .alert.alert-warning
+                    %ul
+                      - @deliveryaddress.errors.full_messages.each do |message|
+                        %li{style: "color:red"} 
+                          - if message.include?("電話番号")
+                            = message.delete!("Translation missing: ja")
           .form-group
             %p.info-text__end 「登録する」のボタンを押すことにより、利用規約に同意したものとみなします
             .action

--- a/app/views/users/registrations/new_profileaddresses.html.haml
+++ b/app/views/users/registrations/new_profileaddresses.html.haml
@@ -10,13 +10,6 @@
         = form_with(model: @profileaddress,url: deliveryaddresses_path,local: true,method: :post) do |f|
           -# = render "devise/shared/error_messages", resource: resource
             ↑だとエラー表示呼び出せないので、下のコードを記述
-          -if @profileaddress.errors.any?
-            .alert.alert-warning
-              %ul
-                - @profileaddress.errors.full_messages.each do |message|
-                  %li 
-                    = message.delete!("Translation missing: ja")
-                    
 
           .form-group
             郵便番号  

--- a/app/views/users/registrations/new_profileaddresses.html.haml
+++ b/app/views/users/registrations/new_profileaddresses.html.haml
@@ -25,7 +25,15 @@
             %br 
             .field
               = f.text_field :postal_code, autofocus: true, autocomplete: "postal_code",placeholder: "ーーー",class: "default"
+              -if @profileaddress.errors.any?
+                .alert.alert-warning
+                  %ul
+                    - @profileaddress.errors.full_messages.each do |message|
+                      %li{style: "color:red"} 
+                        - if message.include?("郵便番号")
+                          = message.delete!("Translation missing: ja")
 
+                    
           .form-group
             -# 後に、都道府県を選べるようコードを書き換えてください
             都道府県
@@ -42,7 +50,14 @@
               任意
             %br 
             .field
-              = f.text_field :city, autofocus: true, autocomplete: "city",placeholder: "ーーー",class: "default" 
+              = f.text_field :city, autofocus: true, autocomplete: "city",placeholder: "ーーー",class: "default"
+              -if @profileaddress.errors.any?
+                .alert.alert-warning
+                  %ul
+                    - @profileaddress.errors.full_messages.each do |message|
+                      %li{style: "color:red"} 
+                        - if message.include?("市区町村")
+                          = message.delete!("Translation missing: ja")
 
           .form-group
             番地
@@ -51,14 +66,26 @@
             %br 
             .field
               = f.text_field :address, autofocus: true, autocomplete: "address",placeholder: "ーーー",class: "default" 
-
+              -if @profileaddress.errors.any?
+                .alert.alert-warning
+                  %ul
+                    - @profileaddress.errors.full_messages.each do |message|
+                      %li{style: "color:red"} 
+                        - if message.include?("番地")
+                          = message.delete!("Translation missing: ja")
           .form-group
             マンション名など部屋号室
             %span.any
               任意
             .field 
               = f.text_field :building, autofocus: true, autocomplete: "building",placeholder: "ーーー",class: "default" 
-
+              -if @profileaddress.errors.any?
+                .alert.alert-warning
+                  %ul
+                    - @profileaddress.errors.full_messages.each do |message|
+                      %li{style: "color:red"} 
+                        - if message.include?("マンション")
+                          = message.delete!("Translation missing: ja")
             %p.info ※本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合がございます。
           
           .form-group


### PR DESCRIPTION
# What
バリデーションによって表示されたエラー文の表示場所をフィールド下に変更した
# Why
どのフィールドでバリデーションがかかったかわかりやすくする為
<img width="1440" alt="スクリーンショット 2020-05-31 21 04 09" src="https://user-images.githubusercontent.com/61651779/83353689-4c102a00-a38f-11ea-9355-41caed83d96b.png">
<img width="1440" alt="スクリーンショット 2020-05-31 21 04 16" src="https://user-images.githubusercontent.com/61651779/83353690-4e728400-a38f-11ea-98d9-fb2f47fac03d.png">
<img width="1440" alt="スクリーンショット 2020-05-31 21 06 57" src="https://user-images.githubusercontent.com/61651779/83353691-503c4780-a38f-11ea-95d5-0221bde924fb.png">
<img width="1440" alt="スクリーンショット 2020-05-31 21 08 02" src="https://user-images.githubusercontent.com/61651779/83353692-529ea180-a38f-11ea-977f-e403e0085884.png">
<img width="1440" alt="スクリーンショット 2020-05-31 21 08 07" src="https://user-images.githubusercontent.com/61651779/83353693-54686500-a38f-11ea-811d-f2dc2c32c127.png">
